### PR TITLE
Improvements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Ilia Sotnikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![Latest release](https://img.shields.io/github/v/release/hostcc/hass-g90)](https://github.com/hostcc/hass-g90/releases/latest)
 
 # Custom Home Assistant integration for G90 security systems
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,47 @@
 
 # Custom Home Assistant integration for G90 security systems
 
-The is a very early preview version.
+## Description
+
+The integration supports G90-based security systems might be distributed under
+different vendors - Golden Security, Kerui etc. Those having G90 in the model
+name has a good chance to be supported - please give it a try and report back.
+
+Actual interface with the security system is implemented via
+[pyg90alarm](https://pypi.org/project/pyg90alarm/) Python package.
+Please see [its documentation](https://pyg90alarm.readthedocs.io/) for more
+details, especially on enabling the device notifications.
+
+Basically, for HomeAssistant to receive notifications from the device on its
+state changes and sensor activity the device should have its IP address set to
+`10.10.10.250`. That is a specific limitation of how device's firmware works.
+
+## Installation
+
+* Install HACS by following [Setup](https://hacs.xyz/docs/setup/prerequisites)
+  and [Configuration](https://hacs.xyz/docs/configuration/basic) steps
+* Add `https://github.com/hostcc/hass-g90/` as custom repository of
+  `Integration` type, as per [Custom
+  repositories](https://hacs.xyz/docs/faq/custom_repositories) instructions for
+  HACS
+* Add the `g90` integration in HomeAssistant
+
+
+## Troubleshooting
+
+If you need to troubleshoot the integration it is recommended to first enable
+debug logging for it, to capture additional details.
+
+For that you'll need to add following options to HomeAssistant's
+`configuration.yaml`. Please note this will also set logging level to `info`
+for all other HomeAssistant components - please adjust `default: info` to fit
+your needs.
+
+```
+logger:
+  default: info
+  logs:
+    pyg90alarm: debug
+    homeassistant.g90: debug
+    custom_components.g90: debug
+```

--- a/custom_components/g90/binary_sensor.py
+++ b/custom_components/g90/binary_sensor.py
@@ -82,7 +82,7 @@ class G90Sensor(BinarySensorEntity):
     def __init__(self, sensor: object, g90_client: object, g90_device: object, g90_guid: str) -> None:
         self._sensor = sensor
         self._g90_client = g90_client
-        self._attr_unique_id = f'{g90_guid}_motion_{sensor.index}'
+        self._attr_unique_id = f'{g90_guid}_sensor_{sensor.index}'
         self._attr_name = sensor.name
         hass_sensor_type = HASS_SENSOR_TYPES_MAPPING.get(sensor.type, None)
         if hass_sensor_type:
@@ -90,7 +90,7 @@ class G90Sensor(BinarySensorEntity):
         sensor.state_callback = self.state_callback
         self._attr_device_info = g90_device
 
-    async def state_callback(self, value):
+    def state_callback(self, value):
         _LOGGER.debug(f'{self.unique_id}: Received state callback: {value}')
         self.schedule_update_ha_state()
 

--- a/custom_components/g90/manifest.json
+++ b/custom_components/g90/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/g90",
   "issue_tracker": "https://github.com/hostcc/hass-g90/issues",
   "requirements": [
-    "pyg90alarm>=1.0.0"
+    "pyg90alarm==1.3.1"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
* Binary sensor: now uses `<GUID>_sensor_<index>` to name the entities,  previously that was `<GUID>_motion_<index>` * Binary sensor: `state_callback` method is now regular, doesn't need to be async
* Alarm control panel: reference G90ArmDisarmTypes enum from`pyg90alarm` package to map to HomeAssistant states. 
* Alarm control panel: Added reading the panel's state right upon the entity is added to HomeAssistant, to avoid the state being unknown up to next poll cycle
* Alarm control panel: `armdisarm_callback` method now sets the panel state as received in its arguments, which avoids unnecessarily sending another command to the panel to read same
* Manifest has been updated for most recent release of pyg90alarm` package